### PR TITLE
Introduces the `ActivityStreamsActivity`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,7 @@ use crate::extended::Actor;
 
 const NAMESPACE: &str = "https://www.w3.org/ns/activitystreams";
 
-trait ActivityStreamsSerialize
+pub trait ActivityStreamsSerialize
 where
     Self: Serialize,
 {

--- a/src/core.rs
+++ b/src/core.rs
@@ -268,6 +268,27 @@ impl ActivityStreamsLinkBuilder {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ActivityStreamsActivity {}
+
+impl ActivityStreamsSerialize for ActivityStreamsActivity {
+    fn from_json(json: String) -> Self {
+        ActivityStreamsActivity {}
+    }
+}
+
+pub struct ActivityStreamsActivityBuilder {}
+
+impl ActivityStreamsActivityBuilder {
+    pub fn new() -> Self {
+        ActivityStreamsActivityBuilder {}
+    }
+
+    pub fn build() -> ActivityStreamsActivity {
+        ActivityStreamsActivity {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::core::{

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,4 +1,4 @@
-use crate::core::ActivityStreamsObject;
+use crate::core::{ActivityStreamsObject, ActivityStreamsSerialize};
 
 use serde::{Deserialize, Serialize};
 
@@ -24,14 +24,14 @@ pub struct Actor {
     liked: Option<String>,
 }
 
-impl Actor {
-    pub const TYPE: &'static str = "Actor";
-
-    pub fn to_json(&self) -> String {
-        let serialized = serde_json::to_string(&self).unwrap();
-        println!("serialized = {}", serialized);
-
-        return serialized;
+impl ActivityStreamsSerialize for Actor {
+    fn from_json(json: String) -> Self {
+        ActorBuilder::new(
+            "Actor".to_string(),
+            "todo".to_string(),
+            "unimplemented".to_string(),
+        )
+        .build()
     }
 }
 
@@ -113,6 +113,7 @@ impl ActorBuilder {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::ActivityStreamsSerialize;
     use crate::extended::ActorBuilder;
 
     #[test]

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -7,8 +7,6 @@ pub struct Actor {
     #[serde(flatten)]
     root: ActivityStreamsObject,
 
-    #[serde(rename = "type")]
-    actor_type: String,
     #[serde(rename = "preferredUsername")]
     #[serde(skip_serializing_if = "Option::is_none")]
     preferred_username: Option<String>,
@@ -27,6 +25,8 @@ pub struct Actor {
 }
 
 impl Actor {
+    pub const TYPE: &'static str = "Actor";
+
     pub fn to_json(&self) -> String {
         let serialized = serde_json::to_string(&self).unwrap();
         println!("serialized = {}", serialized);
@@ -38,7 +38,6 @@ impl Actor {
 pub struct ActorBuilder {
     root: ActivityStreamsObject,
 
-    actor_type: String,
     preferred_username: Option<String>,
     summary: Option<String>,
     inbox: Option<String>,
@@ -49,10 +48,9 @@ pub struct ActorBuilder {
 }
 
 impl ActorBuilder {
-    pub fn new(id: String, name: String) -> Self {
+    pub fn new(actor_type: String, id: String, name: String) -> Self {
         ActorBuilder {
-            root: ActivityStreamsObject::new(id, name),
-            actor_type: "Person".to_string(),
+            root: ActivityStreamsObject::new(id, name).object_type(actor_type),
             preferred_username: None,
             summary: None,
             inbox: None,
@@ -102,7 +100,6 @@ impl ActorBuilder {
         Actor {
             root: self.root,
 
-            actor_type: self.actor_type,
             preferred_username: self.preferred_username,
             summary: self.summary,
             inbox: self.inbox,
@@ -121,13 +118,14 @@ mod tests {
     #[test]
     fn create_actor_object() {
         let actual = ActorBuilder::new(
+            "Person".to_string(),
             "https://example.com/person/1234".to_string(),
             "name".to_string(),
         )
         .preferred_username("dma".to_string())
         .build();
         let expected = String::from(
-            r#"{"@context":["https://www.w3.org/ns/activitystreams#Object",{"@language":"en"}],"id":"https://example.com/person/1234","name":"name","type":"Person","preferredUsername":"dma"}"#,
+            r#"{"@context":["https://www.w3.org/ns/activitystreams"],"type":"Person","id":"https://example.com/person/1234","name":"name","preferredUsername":"dma"}"#,
         );
         assert_eq!(actual.to_json(), expected)
     }


### PR DESCRIPTION
Introduces the `ActivityStreamsActivity`

this PR also uses the `ActivityStreamsObject` more consistently as a base class (compositional, but "flattened") most importantly to bring through the "type" correctly.

comparing to individual examples in [the vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/) this seems correct, but the high level objects now have a @context included multiple times which feels wrong? maybe?

PTAL