### PR TITLE
using examples for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ http = "0.2.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 serde_tuple = "0.5.0"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
 http = "0.2.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"

--- a/src/core.rs
+++ b/src/core.rs
@@ -135,6 +135,10 @@ impl ActivityStreamsObjectBuilder {
     pub fn object_type(mut self, object_type: String) -> Self {
         self.object_type = Some(object_type);
         self
+=======
+    pub fn id(mut self, id: String) -> Self {
+        self.id = Some(id);
+        self
     }
 
     pub fn id(mut self, id: Uri) -> Self {

--- a/src/core.rs
+++ b/src/core.rs
@@ -233,7 +233,7 @@ impl ActivityStreamsSerialize for ActivityStreamsPreview {
 }
 
 pub struct ActivityStreamsPreviewBuilder {
-    base: ActivityStreamsObject,
+    base: ActivityStreamsObjectBuilder,
     duration: Option<String>,
     url: Option<ActivityStreamsUri>,
 }
@@ -262,7 +262,7 @@ impl ActivityStreamsPreviewBuilder {
 
     pub fn build(self) -> ActivityStreamsPreview {
         ActivityStreamsPreview {
-            base: self.base,
+            base: self.base.build(),
             duration: self.duration,
             url: self.url,
         }
@@ -395,18 +395,15 @@ pub struct ActivityStreamsActivity {
     instrument: Option<String>, // TODO: ActivityStreamsInstrument
 }
 
-impl ActivityStreamsActivity {
-    pub const TYPE: &'static str = "Activity";
-}
-
 impl ActivityStreamsSerialize for ActivityStreamsActivity {
     fn from_json(json: String) -> Self {
-        ActivityStreamsActivityBuilder::new("unimplemented".to_string()).build()
+        ActivityStreamsActivityBuilder::new("unknown".to_string(), "unimplemented".to_string())
+            .build()
     }
 }
 
 pub struct ActivityStreamsActivityBuilder {
-    base: ActivityStreamsObject,
+    base: ActivityStreamsObjectBuilder,
     summary: String,
     actor: Option<Actor>,
     object: Option<ActivityStreamsObject>,
@@ -417,7 +414,7 @@ pub struct ActivityStreamsActivityBuilder {
 }
 
 impl ActivityStreamsActivityBuilder {
-    pub fn new(summary: String) -> Self {
+    pub fn new(activity_type: String, summary: String) -> Self {
         ActivityStreamsActivityBuilder {
             base: ActivityStreamsObjectBuilder::new()
                 .object_type(ActivityStreamsActivity::TYPE.to_string())
@@ -464,7 +461,7 @@ impl ActivityStreamsActivityBuilder {
 
     pub fn build(self) -> ActivityStreamsActivity {
         ActivityStreamsActivity {
-            base: self.base,
+            base: self.base.build(),
             summary: self.summary,
             actor: self.actor,
             object: self.object,

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,6 @@
 use chrono::NaiveDateTime;
 use http::Uri;
 use serde::{Deserialize, Serialize};
-use serde_tuple::*;
 
 use crate::extended::{Actor, ActorBuilder};
 
@@ -24,6 +23,31 @@ where
     fn from_json(json: String) -> Self;
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ActivityStreamsDocument<T: ActivityStreamsSerialize> {
+    #[serde(rename = "@context")]
+    context: ActivityStreamsContext,
+
+    #[serde(flatten)]
+    object: T,
+}
+
+impl<T: ActivityStreamsSerialize> ActivityStreamsSerialize for ActivityStreamsDocument<T> {
+    fn from_json(_json: String) -> Self {
+        ActivityStreamsDocument {
+            context: ActivityStreamsContextBuilder::new().build(),
+            // TODO: figure out how to know what type this is
+            object: T::from_json(_json),
+        }
+    }
+}
+
+impl<T: ActivityStreamsSerialize> ActivityStreamsDocument<T> {
+    pub fn new(context: ActivityStreamsContext, object: T) -> Self {
+        ActivityStreamsDocument { context, object }
+    }
+}
+
 /// JSON-LD uses the special @context property to define the processing context.
 /// The value of the @context property is defined by the [JSON-LD]
 /// specification. Implementations producing Activity Streams 2.0 documents
@@ -33,18 +57,20 @@ where
 /// alternative URL "http://www.w3.org/ns/activitystreams" instead. This can be
 /// done using a string, object, or array.
 /// https://www.w3.org/TR/activitystreams-core/#jsonld
-#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActivityStreamsContext {
+    #[serde(rename = "@vocab")]
     namespace: String,
 
     // TODO: figure out how to extend this per the above array/object options.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    language: Option<ActivityStreamsContextLanguage>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "@language")]
+    language: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct ActivityStreamsContextBuilder {
     namespace: String,
-    language: Option<ActivityStreamsContextLanguage>,
+    language: Option<String>,
 }
 
 impl ActivityStreamsContextBuilder {
@@ -59,7 +85,7 @@ impl ActivityStreamsContextBuilder {
 
     // TODO: extend this to other options per the docs
     pub fn language(mut self, language: String) -> Self {
-        self.language = Some(ActivityStreamsContextLanguage { language });
+        self.language = Some(language);
         self
     }
 
@@ -69,12 +95,6 @@ impl ActivityStreamsContextBuilder {
             language: self.language,
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ActivityStreamsContextLanguage {
-    #[serde(rename = "@language")]
-    language: String,
 }
 
 /// The Object is the primary base type for the Activity Streams vocabulary.
@@ -88,11 +108,8 @@ pub struct ActivityStreamsContextLanguage {
 /// summary | summaryMap | tag | updated | url | to | bto | cc | bcc |
 /// mediaType | duration
 /// All properties are optional (including the id and type).
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActivityStreamsObject {
-    #[serde(rename = "@context")]
-    context: ActivityStreamsContext,
-
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     object_type: Option<String>,
 
@@ -107,42 +124,32 @@ pub struct ActivityStreamsObject {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     published: Option<NaiveDateTime>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<Box<ActivityStreamsLink>>,
 }
 
 #[derive(Clone)]
 pub struct ActivityStreamsObjectBuilder {
-    context: ActivityStreamsContext,
     object_type: Option<String>,
     // TODO: actually an IRI: consider https://docs.rs/iref/latest/iref/
     id: Option<Uri>,
     name: Option<String>,
     url: Option<Uri>,
     published: Option<NaiveDateTime>,
+    image: Option<ActivityStreamsLinkBuilder>,
     // TODO: more fields
 }
 
 impl ActivityStreamsObjectBuilder {
     pub fn new() -> Self {
         ActivityStreamsObjectBuilder {
-            context: ActivityStreamsContextBuilder::new().build(),
             object_type: None,
             id: None,
             name: None,
             url: None,
             published: None,
-        }
-    }
-
-    pub fn new_with_language(language: String) -> Self {
-        ActivityStreamsObjectBuilder {
-            context: ActivityStreamsContextBuilder::new()
-                .language(language)
-                .build(),
-            object_type: None,
-            id: None,
-            name: None,
-            url: None,
-            published: None,
+            image: None,
         }
     }
 
@@ -171,9 +178,13 @@ impl ActivityStreamsObjectBuilder {
         self.clone()
     }
 
+    pub fn image(&mut self, image: ActivityStreamsLinkBuilder) -> Self {
+        self.image = Some(image);
+        self.clone()
+    }
+
     pub fn build(self) -> ActivityStreamsObject {
         ActivityStreamsObject {
-            context: self.context,
             object_type: self.object_type,
             id: match self.id {
                 None => None,
@@ -185,6 +196,10 @@ impl ActivityStreamsObjectBuilder {
                 uri => Some(uri.unwrap().to_string()),
             },
             published: self.published,
+            image: match self.image {
+                None => None,
+                i => Some(Box::new(i.unwrap().build())),
+            },
         }
     }
 }
@@ -195,7 +210,7 @@ impl ActivityStreamsSerialize for ActivityStreamsObject {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActivityStreamsUri {
     href: String,
 
@@ -213,6 +228,7 @@ impl ActivityStreamsSerialize for ActivityStreamsUri {
     }
 }
 
+#[derive(Clone)]
 pub struct ActivityStreamsUriBuilder {
     href: Uri,
     media_type: Option<String>,
@@ -239,7 +255,7 @@ impl ActivityStreamsUriBuilder {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActivityStreamsPreview {
     #[serde(flatten)]
     base: ActivityStreamsObject,
@@ -293,20 +309,19 @@ impl ActivityStreamsPreviewBuilder {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActivityStreamsLink {
-    #[serde(rename = "@context")]
-    context: ActivityStreamsContext,
-
     #[serde(rename = "type")]
     link_type: String,
 
-    href: String,
+    #[serde(flatten)]
+    href: ActivityStreamsUri,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     rel: Vec<String>, // TODO: RFC5988 validation
 
-    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     hreflang: Option<String>, // TODO: BCP47 language tag
@@ -327,16 +342,18 @@ impl ActivityStreamsLink {
 
 impl ActivityStreamsSerialize for ActivityStreamsLink {
     fn from_json(_json: String) -> Self {
-        ActivityStreamsLinkBuilder::new("todo".parse::<Uri>().unwrap(), "unimplemented".to_string())
-            .build()
+        ActivityStreamsLinkBuilder::new(ActivityStreamsUriBuilder::new(
+            "href".parse::<Uri>().unwrap(),
+        ))
+        .build()
     }
 }
 
+#[derive(Clone)]
 pub struct ActivityStreamsLinkBuilder {
-    context: ActivityStreamsContextBuilder,
-    href: Uri,
+    href: ActivityStreamsUriBuilder,
     rel: Vec<String>, // TODO: RFC5988 validation
-    name: String,
+    name: Option<String>,
     hreflang: Option<String>, // TODO: BCP47 language tag
     height: Option<u32>,
     width: Option<u32>,
@@ -344,12 +361,11 @@ pub struct ActivityStreamsLinkBuilder {
 }
 
 impl ActivityStreamsLinkBuilder {
-    pub fn new(href: Uri, name: String) -> Self {
+    pub fn new(href: ActivityStreamsUriBuilder) -> Self {
         ActivityStreamsLinkBuilder {
-            context: ActivityStreamsContextBuilder::new(),
             href,
             rel: Vec::new(),
-            name,
+            name: None,
             hreflang: None,
             height: None,
             width: None,
@@ -359,6 +375,11 @@ impl ActivityStreamsLinkBuilder {
 
     pub fn add_rel(mut self, rel: String) -> Self {
         self.rel.push(rel);
+        self
+    }
+
+    pub fn name(mut self, name: String) -> Self {
+        self.name = Some(name);
         self
     }
 
@@ -384,9 +405,8 @@ impl ActivityStreamsLinkBuilder {
 
     pub fn build(self) -> ActivityStreamsLink {
         ActivityStreamsLink {
-            context: self.context.build(),
             link_type: ActivityStreamsLink::TYPE.to_string(),
-            href: self.href.to_string(),
+            href: self.href.build(),
             rel: self.rel,
             name: self.name,
             hreflang: self.hreflang,
@@ -450,6 +470,11 @@ impl ActivityStreamsActivityBuilder {
         }
     }
 
+    pub fn published(mut self, datetime: NaiveDateTime) -> Self {
+        self.base.published(datetime);
+        self
+    }
+
     pub fn actor(mut self, actor: ActorBuilder) -> Self {
         self.actor = Some(actor);
         self
@@ -505,30 +530,25 @@ impl ActivityStreamsActivityBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        core::{
-            ActivityStreamsLinkBuilder, ActivityStreamsObjectBuilder,
-            ActivityStreamsPreviewBuilder, ActivityStreamsSerialize, ActivityStreamsUriBuilder,
-        },
-        extended::ActorBuilder,
-    };
+    use crate::{core::*, extended::ActorBuilder};
     use http::Uri;
-
-    use super::ActivityStreamsActivityBuilder;
 
     #[test]
     fn create_activity_stream_object() {
-        let actual = ActivityStreamsObjectBuilder::new_with_language("en".to_string())
-            .name("name".to_string())
-            .build();
+        let actual = ActivityStreamsDocument::new(
+            ActivityStreamsContextBuilder::new()
+                .language("en".to_string())
+                .build(),
+            ActivityStreamsObjectBuilder::new()
+                .name("name".to_string())
+                .build(),
+        );
         let expected = String::from(
             r#"{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    {
-      "@language": "en"
-    }
-  ],
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/activitystreams",
+    "@language": "en"
+  },
   "name": "name"
 }"#,
         );
@@ -537,17 +557,20 @@ mod tests {
 
     #[test]
     fn create_link() {
-        let actual = ActivityStreamsLinkBuilder::new(
-            "http://example.org/abc".parse::<Uri>().unwrap(),
-            "An example link".to_string(),
-        )
-        .hreflang("en".to_string())
-        .build();
+        let actual = ActivityStreamsDocument::new(
+            ActivityStreamsContextBuilder::new().build(),
+            ActivityStreamsLinkBuilder::new(ActivityStreamsUriBuilder::new(
+                "http://example.org/abc".parse::<Uri>().unwrap(),
+            ))
+            .name("An example link".to_string())
+            .hreflang("en".to_string())
+            .build(),
+        );
         let expected = String::from(
             r#"{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams"
-  ],
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/activitystreams"
+  },
   "type": "Link",
   "href": "http://example.org/abc",
   "name": "An example link",
@@ -559,21 +582,24 @@ mod tests {
 
     #[test]
     fn create_preview() {
-        let actual = ActivityStreamsPreviewBuilder::new("Video".to_string(), "Trailer".to_string())
-            .duration("PT1M".to_string())
-            .url(
-                ActivityStreamsUriBuilder::new(
-                    "http://example.org/trailer.mkv".parse::<Uri>().unwrap(),
+        let actual = ActivityStreamsDocument::new(
+            ActivityStreamsContextBuilder::new().build(),
+            ActivityStreamsPreviewBuilder::new("Video".to_string(), "Trailer".to_string())
+                .duration("PT1M".to_string())
+                .url(
+                    ActivityStreamsUriBuilder::new(
+                        "http://example.org/trailer.mkv".parse::<Uri>().unwrap(),
+                    )
+                    .media_type("video/mkv".to_string())
+                    .build(),
                 )
-                .media_type("video/mkv".to_string())
                 .build(),
-            )
-            .build();
+        );
         let expected = String::from(
             r#"{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams"
-  ],
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/activitystreams"
+  },
   "type": "Video",
   "name": "Trailer",
   "duration": "PT1M",
@@ -588,36 +614,33 @@ mod tests {
 
     #[test]
     fn create_activity() {
-        let actual = ActivityStreamsActivityBuilder::new(
-            "Activity".to_string(),
-            "Sally did something to a note".to_string(),
-        )
-        .actor(ActorBuilder::new("Person".to_string()).name("Sally".to_string()))
-        .object(
-            ActivityStreamsObjectBuilder::new()
-                .object_type("Note".to_string())
-                .name("A Note".to_string()),
-        )
-        .build();
+        let actual = ActivityStreamsDocument::new(
+            ActivityStreamsContextBuilder::new().build(),
+            ActivityStreamsActivityBuilder::new(
+                "Activity".to_string(),
+                "Sally did something to a note".to_string(),
+            )
+            .actor(ActorBuilder::new("Person".to_string()).name("Sally".to_string()))
+            .object(
+                ActivityStreamsObjectBuilder::new()
+                    .object_type("Note".to_string())
+                    .name("A Note".to_string()),
+            )
+            .build(),
+        );
 
         let expected = String::from(
             r#"{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams"
-  ],
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/activitystreams"
+  },
   "type": "Activity",
   "summary": "Sally did something to a note",
   "actor": {
-    "@context": [
-      "https://www.w3.org/ns/activitystreams"
-    ],
     "type": "Person",
     "name": "Sally"
   },
   "object": {
-    "@context": [
-      "https://www.w3.org/ns/activitystreams"
-    ],
     "type": "Note",
     "name": "A Note"
   }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use http::Uri;
 use serde::{Deserialize, Serialize};
 
@@ -123,7 +123,7 @@ pub struct ActivityStreamsObject {
     url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    published: Option<NaiveDateTime>,
+    published: Option<DateTime<Utc>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     image: Option<Box<ActivityStreamsLink>>,
@@ -136,7 +136,7 @@ pub struct ActivityStreamsObjectBuilder {
     id: Option<Uri>,
     name: Option<String>,
     url: Option<Uri>,
-    published: Option<NaiveDateTime>,
+    published: Option<DateTime<Utc>>,
     image: Option<ActivityStreamsLinkBuilder>,
     // TODO: more fields
 }
@@ -173,7 +173,7 @@ impl ActivityStreamsObjectBuilder {
         self.clone()
     }
 
-    pub fn published(&mut self, datetime: NaiveDateTime) -> Self {
+    pub fn published(&mut self, datetime: DateTime<Utc>) -> Self {
         self.published = Some(datetime);
         self.clone()
     }
@@ -470,7 +470,7 @@ impl ActivityStreamsActivityBuilder {
         }
     }
 
-    pub fn published(mut self, datetime: NaiveDateTime) -> Self {
+    pub fn published(mut self, datetime: DateTime<Utc>) -> Self {
         self.base.published(datetime);
         self
     }
@@ -532,6 +532,7 @@ impl ActivityStreamsActivityBuilder {
 mod tests {
     use crate::{core::*, extended::ActorBuilder};
     use http::Uri;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn create_activity_stream_object() {

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -13,6 +13,8 @@ pub struct Actor {
     #[serde(skip_serializing_if = "Option::is_none")]
     summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     inbox: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     outbox: Option<String>,
@@ -31,10 +33,11 @@ impl ActivityStreamsSerialize for Actor {
 }
 
 pub struct ActorBuilder {
-    base: ActivityStreamsObject,
+    base: ActivityStreamsObjectBuilder,
 
     preferred_username: Option<String>,
     summary: Option<String>,
+    url: Option<Uri>,
     inbox: Option<String>,
     outbox: Option<String>,
     followers: Option<String>,
@@ -45,9 +48,12 @@ pub struct ActorBuilder {
 impl ActorBuilder {
     pub fn new(base: ActivityStreamsObject) -> Self {
         ActorBuilder {
-            base: ActivityStreamsObject::new(actor_type).id(id).name(name),
+            base: ActivityStreamsObjectBuilder::new(actor_type)
+                .id(id)
+                .name(name),
             preferred_username: None,
             summary: None,
+            url: None,
             inbox: None,
             outbox: None,
             followers: None,
@@ -63,6 +69,11 @@ impl ActorBuilder {
 
     pub fn summary(mut self, summary: String) -> Self {
         self.summary = Some(summary);
+        self
+    }
+
+    pub fn url(mut self, url: Uri) -> Self {
+        self.url = Some(url);
         self
     }
 
@@ -93,10 +104,14 @@ impl ActorBuilder {
 
     pub fn build(self) -> Actor {
         Actor {
-            base: self.base,
+            base: self.base.build(),
 
             preferred_username: self.preferred_username,
             summary: self.summary,
+            url: match self.url {
+                None => None,
+                u => u.unwrap().to_string(),
+            },
             inbox: self.inbox,
             outbox: self.outbox,
             followers: self.followers,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -45,7 +45,7 @@ pub struct ActorBuilder {
 impl ActorBuilder {
     pub fn new(base: ActivityStreamsObject) -> Self {
         ActorBuilder {
-            base: base,
+            base: ActivityStreamsObject::new(actor_type).id(id).name(name),
             preferred_username: None,
             summary: None,
             inbox: None,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,4 +1,7 @@
-use crate::core::{ActivityStreamsObject, ActivityStreamsObjectBuilder, ActivityStreamsSerialize};
+use crate::core::{
+    ActivityStreamsLinkBuilder, ActivityStreamsObject, ActivityStreamsObjectBuilder,
+    ActivityStreamsSerialize,
+};
 use chrono::NaiveDateTime;
 use http::Uri;
 use serde::{Deserialize, Serialize};
@@ -77,6 +80,11 @@ impl ActorBuilder {
         self
     }
 
+    pub fn image(mut self, image: ActivityStreamsLinkBuilder) -> Self {
+        self.base.image(image);
+        self
+    }
+
     pub fn preferred_username(mut self, username: String) -> Self {
         self.preferred_username = Some(username);
         self
@@ -129,22 +137,27 @@ impl ActorBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ActivityStreamsSerialize;
+    use crate::core::{
+        ActivityStreamsContextBuilder, ActivityStreamsDocument, ActivityStreamsSerialize,
+    };
     use crate::extended::ActorBuilder;
     use http::Uri;
 
     #[test]
     fn create_actor_object() {
-        let actual = ActorBuilder::new("Person".to_string())
-            .id("https://example.com/person/1234".parse::<Uri>().unwrap())
-            .name("name".to_string())
-            .preferred_username("dma".to_string())
-            .build();
+        let actual = ActivityStreamsDocument::new(
+            ActivityStreamsContextBuilder::new().build(),
+            ActorBuilder::new("Person".to_string())
+                .id("https://example.com/person/1234".parse::<Uri>().unwrap())
+                .name("name".to_string())
+                .preferred_username("dma".to_string())
+                .build(),
+        );
         let expected = String::from(
             r#"{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams"
-  ],
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/activitystreams"
+  },
   "type": "Person",
   "id": "https://example.com/person/1234",
   "name": "name",

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,8 +1,5 @@
-use crate::core::{
-    ActivityStreamsLinkBuilder, ActivityStreamsObject, ActivityStreamsObjectBuilder,
-    ActivityStreamsSerialize,
-};
-use chrono::NaiveDateTime;
+use crate::core::*;
+use chrono::{DateTime, Utc};
 use http::Uri;
 use serde::{Deserialize, Serialize};
 
@@ -75,7 +72,7 @@ impl ActorBuilder {
         self
     }
 
-    pub fn published(mut self, datetime: NaiveDateTime) -> Self {
+    pub fn published(mut self, datetime: DateTime<Utc>) -> Self {
         self.base.published(datetime);
         self
     }
@@ -142,6 +139,7 @@ mod tests {
     };
     use crate::extended::ActorBuilder;
     use http::Uri;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn create_actor_object() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,9 @@ mod tests {
             ActivityStreamsContextBuilder::new().build(),
             ActivityStreamsActivityBuilder::new(
                 "Add".to_string(),
-                "Martin created an image".to_string(),
+                "Martin added an article to his blog".to_string(),
             )
+            // TODO: figure out how to get a 'Z' on this. probably requires a time-zone (so not naive)
             .published(NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55))
             .actor(
                 ActorBuilder::new("Person".to_string())
@@ -77,7 +78,7 @@ mod tests {
                                 .parse::<Uri>()
                                 .unwrap(),
                         )
-                        .media_type("image/jpg".to_string()),
+                        .media_type("image/jpeg".to_string()),
                     )),
             )
             .object(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,11 @@ mod extended;
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveDate;
+    use chrono::{DateTime, NaiveDate, Utc};
     use http::Uri;
+    use pretty_assertions::assert_eq;
 
-    use crate::{
-        core::{
-            ActivityStreamsActivityBuilder, ActivityStreamsContextBuilder, ActivityStreamsDocument,
-            ActivityStreamsLinkBuilder, ActivityStreamsObjectBuilder, ActivityStreamsSerialize,
-            ActivityStreamsUriBuilder,
-        },
-        extended::ActorBuilder,
-    };
+    use crate::{core::*, extended::ActorBuilder};
 
     #[test]
     fn it_works() {
@@ -66,7 +60,10 @@ mod tests {
                 "Martin added an article to his blog".to_string(),
             )
             // TODO: figure out how to get a 'Z' on this. probably requires a time-zone (so not naive)
-            .published(NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55))
+            .published(DateTime::<Utc>::from_utc(
+                NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55),
+                Utc,
+            ))
             .actor(
                 ActorBuilder::new("Person".to_string())
                     .id("http://www.test.example/martin".parse::<Uri>().unwrap())
@@ -120,13 +117,13 @@ mod tests {
       "mediaType": "image/jpeg"
     }
   },
-  "object" : {
+  "object": {
     "type": "Article",
     "id": "http://www.test.example/blog/abc123/xyz",
-    "name": "Why I love Activity Streams"
-    "url": "http://example.org/blog/2011/02/entry",
+    "name": "Why I love Activity Streams",
+    "url": "http://example.org/blog/2011/02/entry"
   },
-  "target" : {
+  "target": {
     "type": "OrderedCollection",
     "id": "http://example.org/blog/",
     "name": "Martin's Blog"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,15 @@ mod extended;
 
 #[cfg(test)]
 mod tests {
+    use chrono::NaiveDate;
+    use http::Uri;
+
     use crate::{
-        core::{ActivityStreamsActivityBuilder, ActivityStreamsObject, ActivityStreamsSerialize},
+        core::{
+            ActivityStreamsActivityBuilder, ActivityStreamsObjectBuilder, ActivityStreamsSerialize,
+        },
         extended::ActorBuilder,
     };
-    use http::Uri;
 
     #[test]
     fn it_works() {
@@ -26,8 +30,8 @@ mod tests {
         .build();
         let expected = r#"{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "summary": "Martin created an image",
   "type": "Create",
+  "summary": "Martin created an image",
   "actor": "http://www.test.example/martin",
   "object":"http://example.org/foo.jpg"
 }"#;
@@ -41,28 +45,30 @@ mod tests {
             "Martin created an image".to_string(),
         )
         .actor(
-            ActorBuilder::new(
-                "Person".to_string(),
-                "http://www.test.example/martin".to_string(),
-                "Martin Smith".to_string(),
-            )
-            .url("http://example.org/martin".parse::<Uri>().unwrap())
-            .published(),
+            ActorBuilder::new("Person".to_string())
+                .id("http://www.test.example/martin".parse::<Uri>().unwrap())
+                .name("Martin Smith".to_string())
+                .url("http://example.org/martin".parse::<Uri>().unwrap())
+                .published(NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55)),
         ) // TODO: take a date-time and convert to string
         .object(
-            ActivityStreamsObject::new("Article".to_string())
-                .id("http://www.test.example/blog/abc123/xyz".to_string())
+            ActivityStreamsObjectBuilder::new()
+                .object_type("Article".to_string())
+                .id("http://www.test.example/blog/abc123/xyz"
+                    .parse::<Uri>()
+                    .unwrap())
                 .name("Why I love Activity Streams".to_string())
                 .url(
                     "http://example.org/blog/2011/02/entry"
                         .parse::<Uri>()
                         .unwrap(),
-                )
-                .target(
-                    ActivityStreamsObject::new("OrderedCollection".to_string())
-                        .id("http://example.org/blog/".to_string())
-                        .name("Martin's Blog".to_string()),
                 ),
+        )
+        .target(
+            ActivityStreamsObjectBuilder::new()
+                .object_type("OrderedCollection".to_string())
+                .id("http://example.org/blog/".parse::<Uri>().unwrap())
+                .name("Martin's Blog".to_string()),
         )
         .build();
         let expected = r#"{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,68 @@ mod extended;
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        core::{ActivityStreamsActivityBuilder, ActivityStreamsObject},
+        extended::ActorBuilder,
+    };
+    use http::Uri;
+
     #[test]
     fn it_works() {
         let result = 2 + 2;
         assert_eq!(result, 4);
+    }
+
+    // A set of tests from https://www.w3.org/TR/activitystreams-core/ examples
+    #[test]
+    fn minimal_activity_3_1() {
+        // TODO
+        //let expected = r#"{"@context":"https://www.w3.org/ns/activitystreams","summary":"Martin created an image","type":"Create","actor":"http://www.test.example/martin","object":"http://example.org/foo.jpg"}"#
+    }
+
+    #[test]
+    fn basic_activity_with_additional_detail_3_2() {
+        // TODO
+        /*
+                let activity = ActivityStreamsActivityBuilder::new(
+                    ActivityStreamsObject::new("Add".to_string()),
+                    "Martin created an image".to_string(),
+                )
+                .actor(ActorBuilder::new("Person".to_string(), "http://www.test.example/martin".to_string(), "Martin Smith".to_string()).url("http://example.org/martin".parse::<Uri>().unwrap())
+        .published()) // TODO: take a date-time and convert to string
+                .object(ActivityStreamsObject::new("Article".to_string()).id("http://www.test.example/blog/abc123/xyz".to_string()).name("Why I love Activity Streams".to_string()).url("http://example.org/blog/2011/02/entry".parse::<Uri>().unwrap())
+                .target(ActivityStreamsObject::new("OrderedCollection".to_string()).id("http://example.org/blog/".to_string()).name("Martin's Blog".to_string()))
+            ).build();
+                let expected = r#"
+                {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "summary": "Martin added an article to his blog",
+                    "type": "Add",
+                    "published": "2015-02-10T15:04:55Z",
+                    "actor": {
+                     "type": "Person",
+                     "id": "http://www.test.example/martin",
+                     "name": "Martin Smith",
+                     "url": "http://example.org/martin",
+                     "image": {
+                       "type": "Link",
+                       "href": "http://example.org/martin/image.jpg",
+                       "mediaType": "image/jpeg"
+                     }
+                    },
+                    "object" : {
+                     "id": "http://www.test.example/blog/abc123/xyz",
+                     "type": "Article",
+                     "url": "http://example.org/blog/2011/02/entry",
+                     "name": "Why I love Activity Streams"
+                    },
+                    "target" : {
+                     "id": "http://example.org/blog/",
+                     "type": "OrderedCollection",
+                     "name": "Martin's Blog"
+                    }
+                  }
+                "#;
+                */
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod extended;
 #[cfg(test)]
 mod tests {
     use crate::{
-        core::{ActivityStreamsActivityBuilder, ActivityStreamsObject},
+        core::{ActivityStreamsActivityBuilder, ActivityStreamsObject, ActivityStreamsSerialize},
         extended::ActorBuilder,
     };
     use http::Uri;
@@ -19,52 +19,80 @@ mod tests {
     #[test]
     fn minimal_activity_3_1() {
         // TODO
-        //let expected = r#"{"@context":"https://www.w3.org/ns/activitystreams","summary":"Martin created an image","type":"Create","actor":"http://www.test.example/martin","object":"http://example.org/foo.jpg"}"#
+        let actual = ActivityStreamsActivityBuilder::new(
+            "Create".to_string(),
+            "Martin created an image".to_string(),
+        )
+        .build();
+        let expected = r#"{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "summary": "Martin created an image",
+  "type": "Create",
+  "actor": "http://www.test.example/martin",
+  "object":"http://example.org/foo.jpg"
+}"#;
+        assert_eq!(actual.to_json_pretty(), expected);
     }
 
     #[test]
     fn basic_activity_with_additional_detail_3_2() {
-        // TODO
-        /*
-                let activity = ActivityStreamsActivityBuilder::new(
-                    ActivityStreamsObject::new("Add".to_string()),
-                    "Martin created an image".to_string(),
+        let actual = ActivityStreamsActivityBuilder::new(
+            "Add".to_string(),
+            "Martin created an image".to_string(),
+        )
+        .actor(
+            ActorBuilder::new(
+                "Person".to_string(),
+                "http://www.test.example/martin".to_string(),
+                "Martin Smith".to_string(),
+            )
+            .url("http://example.org/martin".parse::<Uri>().unwrap())
+            .published(),
+        ) // TODO: take a date-time and convert to string
+        .object(
+            ActivityStreamsObject::new("Article".to_string())
+                .id("http://www.test.example/blog/abc123/xyz".to_string())
+                .name("Why I love Activity Streams".to_string())
+                .url(
+                    "http://example.org/blog/2011/02/entry"
+                        .parse::<Uri>()
+                        .unwrap(),
                 )
-                .actor(ActorBuilder::new("Person".to_string(), "http://www.test.example/martin".to_string(), "Martin Smith".to_string()).url("http://example.org/martin".parse::<Uri>().unwrap())
-        .published()) // TODO: take a date-time and convert to string
-                .object(ActivityStreamsObject::new("Article".to_string()).id("http://www.test.example/blog/abc123/xyz".to_string()).name("Why I love Activity Streams".to_string()).url("http://example.org/blog/2011/02/entry".parse::<Uri>().unwrap())
-                .target(ActivityStreamsObject::new("OrderedCollection".to_string()).id("http://example.org/blog/".to_string()).name("Martin's Blog".to_string()))
-            ).build();
-                let expected = r#"
-                {
-                    "@context": "https://www.w3.org/ns/activitystreams",
-                    "summary": "Martin added an article to his blog",
-                    "type": "Add",
-                    "published": "2015-02-10T15:04:55Z",
-                    "actor": {
-                     "type": "Person",
-                     "id": "http://www.test.example/martin",
-                     "name": "Martin Smith",
-                     "url": "http://example.org/martin",
-                     "image": {
-                       "type": "Link",
-                       "href": "http://example.org/martin/image.jpg",
-                       "mediaType": "image/jpeg"
-                     }
-                    },
-                    "object" : {
-                     "id": "http://www.test.example/blog/abc123/xyz",
-                     "type": "Article",
-                     "url": "http://example.org/blog/2011/02/entry",
-                     "name": "Why I love Activity Streams"
-                    },
-                    "target" : {
-                     "id": "http://example.org/blog/",
-                     "type": "OrderedCollection",
-                     "name": "Martin's Blog"
-                    }
-                  }
-                "#;
-                */
+                .target(
+                    ActivityStreamsObject::new("OrderedCollection".to_string())
+                        .id("http://example.org/blog/".to_string())
+                        .name("Martin's Blog".to_string()),
+                ),
+        )
+        .build();
+        let expected = r#"{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "summary": "Martin added an article to his blog",
+  "type": "Add",
+  "published": "2015-02-10T15:04:55Z",
+  "actor": {
+    "type": "Person",
+    "id": "http://www.test.example/martin",
+    "name": "Martin Smith",
+    "url": "http://example.org/martin",
+    "image": {
+      "type": "Link",
+      "href": "http://example.org/martin/image.jpg",
+      "mediaType": "image/jpeg"
+    }
+  },
+  "object" : {
+    "id": "http://www.test.example/blog/abc123/xyz",
+    "type": "Article",
+    "url": "http://example.org/blog/2011/02/entry",
+    "name": "Why I love Activity Streams"
+  },
+  "target" : {
+    "id": "http://example.org/blog/",
+    "type": "OrderedCollection",
+    "name": "Martin's Blog"
+  }
+}"#;
+        assert_eq!(actual.to_json_pretty(), expected);
     }
 }


### PR DESCRIPTION
set up some tests at the top level library that match the examples [here](https://www.w3.org/TR/activitystreams-core/#examples)

these tests pass thanks to the addition of a `Document` type that holds the top-level context and whatever else needs serializing.  Seems to work pretty well i think, though deserialization will need some thought perhaps.